### PR TITLE
Build cpp-simple with and without docker

### DIFF
--- a/examples/cpp-simple/CMakeLists.txt
+++ b/examples/cpp-simple/CMakeLists.txt
@@ -48,3 +48,6 @@ target_link_libraries(${PROJECT_NAME} PUBLIC agones)
 if (MSVS)
   target_compile_options(${PROJECT_NAME} PUBLIC /wd4101 /wd4146 /wd4251 /wd4661)
 endif()
+
+# Installation
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME} RUNTIME DESTINATION .)

--- a/examples/cpp-simple/Dockerfile
+++ b/examples/cpp-simple/Dockerfile
@@ -17,7 +17,6 @@ FROM gcc:8 as builder
 WORKDIR /project
 
 COPY ./sdks/cpp sdk
-COPY ./examples/cpp-simple cpp-simple
 
 ADD https://cmake.org/files/v3.14/cmake-3.14.1-Linux-x86_64.sh /cmake-3.14.1-Linux-x86_64.sh
 RUN mkdir /opt/cmake
@@ -30,15 +29,17 @@ RUN cd sdk && mkdir -p .build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" -Wno-dev && \
     cmake --build . --target install
 
+COPY ./examples/cpp-simple cpp-simple
+
 RUN cd cpp-simple && mkdir -p .build && \
     cd .build && \
-    cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release && \
-    cmake --build .
+    cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.bin && \
+    cmake --build . --target install
 
 FROM debian:stretch
 RUN useradd -m server
 
-COPY --from=builder /project/cpp-simple/.build/cpp-simple /home/server/cpp-simple
+COPY --from=builder /project/cpp-simple/.build/.bin /home/server/cpp-simple
 RUN chown -R server /home/server && \
     chmod o+x /home/server/cpp-simple
 

--- a/examples/cpp-simple/Makefile
+++ b/examples/cpp-simple/Makefile
@@ -23,10 +23,6 @@
 #     \_/ \__,_|_|  |_|\__,_|_.__/|_|\___|___/
 #
 
-CXX = g++
-CPPFLAGS += -I/usr/local/include -pthread
-CXXFLAGS += -std=c++11
-LDFLAGS += -L/usr/local/lib -lagonessdk -lgrpc++_unsecure -lgrpc -lprotobuf -lpthread -ldl
 REPOSITORY = gcr.io/agones-images
 
 # Directory that this Makefile is in.
@@ -42,25 +38,16 @@ root_path = $(realpath $(project_path)/../..)
 #    |_|\__,_|_|  \__, |\___|\__|___/
 #                 |___/
 
-# build the library
-build: ensure-bin server-dynamic server-static
+# build the cpp-simple binary
+build:
+	cd $(project_path) && mkdir -p .build && \
+	cd .build && \
+	cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.bin -DCMAKE_PREFIX_PATH=$(root_path)/sdks/cpp/.build/.install && \
+	cmake --build . --target install
 
 # Build a docker image for the server, and tag it
 build-image:
 	cd $(root_path) && docker build -f $(project_path)/Dockerfile --tag=$(server_tag) .
 
-# make the server executable
-server-dynamic: server.o
-	$(CXX) $^ $(LDFLAGS) -o $(project_path)bin/$@
-
-# make the server executable
-server-static: server.o
-	$(CXX) $^ $(LDFLAGS) -o $(project_path)bin/$@ -static
-
-# make sure the bin directory exists
-ensure-bin:
-	-mkdir $(project_path)/bin
-
 clean:
-	-rm -r $(project_path)/bin
-	-rm *.o
+	-rm -r $(project_path)/.build


### PR DESCRIPTION
For local (non docker) build it is necessary to have compiled cpp sdk.
Maybe we should add a sdk check+build step to cpp-simple/Makefile?